### PR TITLE
addition of common_path method (issue #2)

### DIFF
--- a/fossor/checks/dmesg.py
+++ b/fossor/checks/dmesg.py
@@ -8,7 +8,7 @@ import logging
 
 from datetime import datetime, timedelta
 from fossor.checks.check import Check
-from fossor.utils.misc import iswithintimerange
+from fossor.utils.misc import iswithintimerange, common_path
 
 TIME_FORMAT = '%b %d %H:%M:%S'
 
@@ -25,7 +25,7 @@ class Dmesg(Check):
 
     def _getdmesgoutput(self, start_time=None, end_time=None):
         result = []
-        out, err, returncode = self.shell_call('/usr/bin/dmesg', stream=True)
+        out, err, returncode = self.shell_call(common_path(['/usr/bin/dmesg', '/bin/dmesg']), stream=True)
         boot_time = self._get_boot_time()
 
         dmesg_pattern = re.compile('\[(.*?)\] (.*)')

--- a/fossor/checks/memusage.py
+++ b/fossor/checks/memusage.py
@@ -5,6 +5,7 @@ import time
 import re
 import platform
 from fossor.checks.check import Check
+from fossor.utils.misc import common_path
 
 
 class MemUsage(Check):
@@ -24,7 +25,7 @@ class MemUsage(Check):
         used = meminfo['MemTotal'] - act_free
         perc_used = (used/meminfo['MemTotal'])*100
 
-        out, err, return_code = self.shell_call('dmesg')
+        out, err, return_code = self.shell_call(common_path(['/usr/bin/dmesg', '/bin/dmesg']))
 
         if perc_used >= CRITICAL_THRESH or 'oom-killer' in out:
             res = 'High Memory Use!\nMemTotal: {0:.0f} kib\nUsed: {1:.0f} kib ({2:.0f}%)'.format(

--- a/fossor/utils/misc.py
+++ b/fossor/utils/misc.py
@@ -3,6 +3,7 @@
 
 import sys
 import logging
+import os
 import psutil
 import time
 
@@ -148,3 +149,13 @@ def get_traceback_variables():
             line = line.format(key=key, value=value)
             output.append(line)
     return '\n'.join(output)
+
+
+def common_path(binaries):
+    '''Returns the first file that os.path.isfile() from the supplied list of binaries. If none
+    of the supplied list of files exist, a FileNoteFoundError is raised.'''
+
+    for filename in binaries:
+        if os.path.isfile(filename):
+            return filename
+    raise FileNotFoundError(', '.join(binaries))

--- a/test/test_check_memusage.py
+++ b/test/test_check_memusage.py
@@ -3,14 +3,14 @@
 
 import mock
 
-from fossor.checks.memusage import MemUsage
-
 
 @mock.patch('platform.system')
 @mock.patch('fossor.checks.memusage.MemUsage.get_meminfo')
 @mock.patch('fossor.checks.memusage.MemUsage.get_time')
 @mock.patch('fossor.plugin.Plugin.shell_call')
-def test_mem_usage(sc_mock, time_mock, mem_mock, ps_mock):
+@mock.patch('fossor.utils.misc.common_path', return_value='/usr/bin/dmesg')
+def test_mem_usage(cp_mock, sc_mock, time_mock, mem_mock, ps_mock):
+    from fossor.checks.memusage import MemUsage
 
     line1 = '[11686.040460] flasherav invoked oom-killer: gfp_mask=0x201da, order=0, oom_adj=0, oom_score_adj=0'
     line2 = '[4680581.563150] perl invoked oom-killer: gfp_mask=0x380da, order=0, oom_score_adj=0'

--- a/test/test_check_netiface_errors.py
+++ b/test/test_check_netiface_errors.py
@@ -2,7 +2,6 @@
 # See LICENSE in the project root for license information.
 
 import mock
-import pytest
 
 from fossor.checks.netiface_errors import NetIFace
 


### PR DESCRIPTION
common_path performs a simple os.path.isfile check against a target list of strings. This method is meant to be called by plugins who wish to execute a shell_call(), allowing cross platform support/resolution of common binaries.