### PR TITLE
Cleanup variable access

### DIFF
--- a/fossor/checks/dmesg.py
+++ b/fossor/checks/dmesg.py
@@ -16,8 +16,8 @@ TIME_FORMAT = '%b %d %H:%M:%S'
 class Dmesg(Check):
 
     def run(self, variables):
-        start_time = int(variables['start_time']) if 'start_time' in variables else None
-        end_time = int(variables['end_time']) if 'end_time' in variables else None
+        start_time = variables.get('start_time', None)
+        end_time = variables.get('end_time', None)
 
         result = self._getdmesgoutput(start_time=start_time, end_time=end_time)
         if result:

--- a/fossor/checks/listvariables.py
+++ b/fossor/checks/listvariables.py
@@ -8,8 +8,7 @@ class ListVariables(Check):
 
     def run(self, variables):
         '''If verbose is on, list all variables in use'''
-        verbose = variables.get('verbose')
-        if not verbose:
-            return
-        result = [f"{name}={value}" for name, value in variables.items()]
-        return "\n".join(result)
+        verbose = variables.get('verbose', None)
+        if verbose:
+            result = [f"{name}={value}" for name, value in variables.items()]
+            return "\n".join(result)

--- a/fossor/checks/other_users.py
+++ b/fossor/checks/other_users.py
@@ -7,12 +7,8 @@ from fossor.checks.check import Check
 class OtherUsers(Check):
     """Checks for other users logged into the host box other than the current user."""
     def run(self, variables):
-        if 'OtherUsers' in variables:
+        other_users = variables.get('OtherUsers', None)
+        if other_users:
             msg = 'Other users logged into this box: '
-            user_list = ', '.join(str(u) for u in variables['OtherUsers'].split())
+            user_list = ', '.join(str(u) for u in other_users.split())
             return msg + user_list + '\n'
-
-
-if __name__ == '__main__':
-    t = OtherUsers()
-    print(t.run({}))

--- a/fossor/checks/similar_log_errors.py
+++ b/fossor/checks/similar_log_errors.py
@@ -2,7 +2,7 @@
 # See LICENSE in the project root for license information.
 
 from difflib import SequenceMatcher
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 
 from fossor.checks.check import Check
 
@@ -29,14 +29,15 @@ class SimilarLogErrors(Check):
     def run(self, variables):
         result = ''
 
-        if 'LogFiles' not in variables:
+        log_files = variables.get('LogFiles', None)
+        if not log_files:
             return
 
-        log_files = variables['LogFiles']
         log_files = self._remove_blacklisted_logs(log_files)
         self.log.debug(f"log_files: {log_files}")
 
-        pool = Pool(len(log_files))
+        max_pool_threads = cpu_count() * 2
+        pool = Pool(max_pool_threads)
         pool_results = pool.map(self.get_error_pattern_counts, log_files)
 
         for filename, common_lines in pool_results:

--- a/fossor/checks/system_log_volume.py
+++ b/fossor/checks/system_log_volume.py
@@ -23,9 +23,9 @@ class SystemLogVolume(Check):
 
     def run(self, variables: dict):
         '''Print back system graphs if log volume has changed significantly.'''
-        start_time = variables['start_time'] if 'start_time' in variables else None
-        end_time = variables['end_time'] if 'end_time' in variables else None
-        max_width = variables['MaxPluginOutputWidth'] if 'MaxPluginOutputWidth' in variables else None
+        start_time = variables.get('start_time', None)
+        end_time = variables.get('end_time', None)
+        max_width = variables.get('MaxPluginOutputWidth', None)
 
         file_line_counts = self.get_line_counts(start_time, end_time)
         g = Grapher()

--- a/fossor/reports/stdout.py
+++ b/fossor/reports/stdout.py
@@ -7,13 +7,14 @@ from fossor.reports.report import Report
 
 class StdOut(Report):
     def run(self, variables, report_input, **kwargs):
-        if 'TerminalWidth' in variables:
-            kwargs['width'] = int(variables['TerminalWidth'])
-        timeout = variables['timeout'] if 'timeout' in variables else 600
+        terminal_width = variables.get('TerminalWidth', None)
+        if terminal_width:
+            kwargs['width'] = terminal_width
+        timeout = variables.get('timeout', 600)
         truncate = variables.get('truncate', True)
         if truncate:
             kwargs['max_lines_per_plugin'] = 20
-        debug = variables['debug'] if 'debug' in variables else False
+        debug = variables.get('debug', False)
 
         # If in debug mode, don't print line by line, print all at once in the print statement below instead
         # This prevents logs lines becoming interspersed with the report.

--- a/fossor/variables/logfiles.py
+++ b/fossor/variables/logfiles.py
@@ -7,9 +7,10 @@ from fossor.variables.variable import Variable
 
 class LogFiles(Variable):
     def run(self, variables):
-        if 'Pid' not in variables:
+        pid = variables.get('Pid', None)
+        if not pid:
             return
-        pid = int(variables['Pid'])
+
         p = psutil.Process(pid)
         log_files = None
 

--- a/fossor/variables/pid.py
+++ b/fossor/variables/pid.py
@@ -10,30 +10,31 @@ from fossor.utils.misc import psutil_exceptions
 
 class Pid(Variable):
     def run(self, variables):
-        if 'Product' not in variables:
-            return
-        product = variables['Product']
-        for p in psutil.process_iter():
-            try:
-                if product.startswith(p.name()):
-                    return p.pid
-            except psutil_exceptions:
-                continue
+        product = variables.get('Product', None)
+        if product:
+            for p in psutil.process_iter():
+                try:
+                    if product.lower().startswith(p.name().lower()):
+                        return p.pid
+                except psutil_exceptions:
+                    continue
 
 
 class PidCwd(Variable):
     def run(self, variables):
-        if 'Pid' in variables:
+        pid = variables.get('Pid', None)
+        if pid:
             try:
-                return os.readlink('/proc/{pid}/cwd'.format(pid=variables['Pid']))
+                return os.readlink(f'/proc/{pid}/cwd')
             except PermissionError:
                 pass
 
 
 class PidExe(Variable):
     def run(self, variables):
-        if 'Pid' in variables:
+        pid = variables.get('Pid', None)
+        if pid:
             try:
-                return os.readlink('/proc/{pid}/exe'.format(pid=variables['Pid']))
+                return os.readlink(f'/proc/{pid}/exe')
             except PermissionError:
                 pass

--- a/fossor/variables/terminal_size.py
+++ b/fossor/variables/terminal_size.py
@@ -20,6 +20,6 @@ class TerminalWidth(Variable):
 class MaxPluginOutputWidth(Variable):
     def run(self, variables):
         '''If plugins keep their output width under this amount, they won't be truncated.'''
-        if 'TerminalWidth' not in variables:
-            return
-        return int(variables['TerminalWidth']) - TABLE_FORMATTING_WIDTH
+        terminal_width = variables.get('TerminalWidth', None)
+        if terminal_width:
+            return terminal_width - TABLE_FORMATTING_WIDTH

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except IOError:
 
 setup(
     name='fossor',
-    version='1.1.0',
+    version='1.1.1',
     description=description,
     long_description=description,
     url='https://github.com/linkedin/fossor',


### PR DESCRIPTION
This cleans up many of the accesses to the variables dictionary. There were several instances where the logic could be simplified and where we can avoid casting the result since all variables are converted to simple types on import.